### PR TITLE
Add missing column header

### DIFF
--- a/2014/20141104__ct__general__groton__precinct.csv
+++ b/2014/20141104__ct__general__groton__precinct.csv
@@ -1,4 +1,4 @@
-County,Precinct,Office,District,Party,,Poll,Abs,Unknown
+County,Precinct,Office,District,Party,Candidate,Poll,Abs,Unknown
 New London,Groton 1,Governor,,REP,Thomas C. Foley,501,65,3
 New London,Groton 1,Governor,,IND,Thomas C. Foley,26,7,1
 New London,Groton 1,Governor,,UNK,Thomas C. Foley,0,0,0


### PR DESCRIPTION
There was a missing column header, which most likely should be `Candidate`.

These headers should all be lowercase for consistency, but we can fix that separately in the future.